### PR TITLE
Allow app behaviour in iOS devices

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,6 +8,7 @@
     <!-- Allow installing the app to the homescreen -->
     <link rel="manifest" href="manifest.json">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <title>React.js Boilerplate</title>
   </head>
   <body>


### PR DESCRIPTION
I added one line in the `app/index.html`in order to allow app behavior, as you already provided for android devices, on iOS devices.
<meta name="apple-mobile-web-app-capable" content="yes">` emulate the same behavior of `<meta name="mobile-web-app-capable" content="yes">` but on apple devices.